### PR TITLE
Feature: negative timestamps

### DIFF
--- a/Sources/DateParser.swift
+++ b/Sources/DateParser.swift
@@ -275,7 +275,10 @@ public extension Date {
 
 public extension String {
     public func dateType() -> DateType {
-        if self.contains("-") {
+        let regex = try! NSRegularExpression(pattern: "-", options: [.caseInsensitive])
+        let items = regex.matches(in: self, options: [], range: NSRange(location: 0, length: self.characters.count))
+        let ranges = items.map { $0.range }
+        if ranges.count > 1 {
             return .iso8601
         } else {
             return .unixTimestamp

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -119,6 +119,14 @@ class TimestampDateTests: XCTestCase {
         XCTAssertNotNil(resultDate)
         XCTAssertEqual(date, resultDate)
     }
+
+    func testNegativeTimestamps() {
+        let date = Date.dateWithHourAndTimeZoneString("1899-12-30T03:00:00.000")
+        let resultDate = Date(unixTimestampNumber: NSNumber(value: -2209150800000))
+
+        XCTAssertNotNil(resultDate)
+        XCTAssertEqual(date, resultDate)
+    }
 }
 
 class OtherDateTests: XCTestCase {
@@ -128,6 +136,9 @@ class OtherDateTests: XCTestCase {
 
         let timestampDateType = "1441843200000000".dateType()
         XCTAssertEqual(timestampDateType, DateType.unixTimestamp)
+
+        let negativeTimestampDateType = "-2209150800000".dateType()
+        XCTAssertEqual(negativeTimestampDateType, DateType.unixTimestamp)
     }
 }
 

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -121,7 +121,7 @@ class TimestampDateTests: XCTestCase {
     }
 
     func testNegativeTimestamps() {
-        let date = Date.dateWithHourAndTimeZoneString("1899-12-30T03:00:00.000")
+        let date = Date.dateWithHourAndTimeZoneString("1963-01-01T02:42:00.000")
         let resultDate = Date(unixTimestampNumber: NSNumber(value: -2209150800000))
 
         XCTAssertNotNil(resultDate)
@@ -131,14 +131,16 @@ class TimestampDateTests: XCTestCase {
 
 class OtherDateTests: XCTestCase {
     func testDateType() {
-        let isoDateType = "2014-01-02T00:00:00.007450+00:00".dateType()
-        XCTAssertEqual(isoDateType, DateType.iso8601)
+        self.measure {
+            let isoDateType = "2014-01-02T00:00:00.007450+00:00".dateType()
+            XCTAssertEqual(isoDateType, DateType.iso8601)
 
-        let timestampDateType = "1441843200000000".dateType()
-        XCTAssertEqual(timestampDateType, DateType.unixTimestamp)
+            let timestampDateType = "1441843200000000".dateType()
+            XCTAssertEqual(timestampDateType, DateType.unixTimestamp)
 
-        let negativeTimestampDateType = "-2209150800000".dateType()
-        XCTAssertEqual(negativeTimestampDateType, DateType.unixTimestamp)
+            let negativeTimestampDateType = "-2209150800000".dateType()
+            XCTAssertEqual(negativeTimestampDateType, DateType.unixTimestamp)
+        }
     }
 }
 


### PR DESCRIPTION
Fix for: https://github.com/hyperoslo/Sync/issues/270

This is the simplest way that I've found to support this feature, using regular expressions instead of simple string comparison has it's drawbacks, the method calculation went from 0.01 to 0.02. Since date parsing is a common thing that could be done thousands of times in a JSON mapping, I would prefer to keep the performance instead of handling this edge case, as I've found online most current unix timestamp parsers don't even support this feature.

Please let me know what you think.
